### PR TITLE
Implement derive(SizeWith) using SizeWith recursively on fields. Fixes #12

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -12,7 +12,7 @@ struct Data {
 
 use scroll::{Pread, Pwrite, Cread, LE};
 
-fn main (){
+fn main () {
     let bytes = [0xefu8, 0xbe, 0xad, 0xde, 0, 0, 0, 0, 0, 0, 224, 63, 0xad, 0xde, 0xef, 0xbe];
     let data: Data = bytes.pread_with(0, LE).unwrap();
     println!("data: {:?}", &data);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -154,6 +154,7 @@ fn test_nested_struct() {
         2, 0, 0, 0,
     ];
     let size = Data7B::size_with(&LE);
+    assert_eq!(size, 12);
     let mut read = 0;
     let b: Data7B = BYTES.gread_with(&mut read, LE).unwrap();
     assert_eq!(b.a.y, 1);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -9,6 +9,7 @@ struct Data {
 }
 
 use scroll::{Pread, Pwrite, Cread, Cwrite, LE};
+use scroll::ctx::SizeWith;
 
 #[test]
 fn test_data (){
@@ -131,4 +132,31 @@ fn test_array_copy (){
     println!("data.name: {:?}", name);
     assert_eq!(data.id, 0xbeefedde);
     assert_eq!(name, "hell");
+}
+
+#[derive(Pread, SizeWith)]
+struct Data7A {
+    pub y: u64,
+    pub x: u32,
+}
+
+#[derive(Pread, SizeWith)]
+struct Data7B {
+    pub a: Data7A,
+}
+
+#[test]
+fn test_nested_struct() {
+    const BYTES: [u8; 12] = [
+        // y: u64
+        1, 0, 0, 0, 0, 0, 0, 0,
+        // x: u32
+        2, 0, 0, 0,
+    ];
+    let size = Data7B::size_with(&LE);
+    let mut read = 0;
+    let b: Data7B = BYTES.gread_with(&mut read, LE).unwrap();
+    assert_eq!(b.a.y, 1);
+    assert_eq!(b.a.x, 2);
+    assert_eq!(read, size);
 }


### PR DESCRIPTION
This change makes the implementation of derive(SizeWith) recursively call
the SizeWith implementation on all struct fields and return the sum. I
verified that the compiler winds up constant-folding it all down to a single
constant for the examples I tried. This should provide reliable sizes for
structs even if they're not repr(packed).