### PR TITLE
Use references to struct fields in `derive(Pwrite)` implementation so it will work with non-`Copy` types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,13 +79,13 @@ fn impl_try_into_ctx(name: &syn::Ident, fields: &syn::FieldsNamed) -> proc_macro
             &syn::Type::Array(_) => {
                 quote! {
                     for i in 0..self.#ident.len() {
-                        dst.gwrite_with(self.#ident[i], offset, ctx)?;
+                        dst.gwrite_with(&self.#ident[i], offset, ctx)?;
                     }
                 }
             },
             _ => {
                 quote! {
-                    dst.gwrite_with(self.#ident, offset, ctx)?
+                    dst.gwrite_with(&self.#ident, offset, ctx)?
                 }
             }
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -134,30 +134,27 @@ fn test_array_copy (){
     assert_eq!(name, "hell");
 }
 
-#[derive(Pread, SizeWith)]
+#[derive(Debug, PartialEq, Eq, Pread, Pwrite, SizeWith)]
 struct Data7A {
     pub y: u64,
     pub x: u32,
 }
 
-#[derive(Pread, SizeWith)]
+#[derive(Debug, PartialEq, Eq, Pread, Pwrite, SizeWith)]
 struct Data7B {
     pub a: Data7A,
 }
 
 #[test]
 fn test_nested_struct() {
-    const BYTES: [u8; 12] = [
-        // y: u64
-        1, 0, 0, 0, 0, 0, 0, 0,
-        // x: u32
-        2, 0, 0, 0,
-    ];
+    let b = Data7B { a: Data7A { y: 1, x: 2 } };
     let size = Data7B::size_with(&LE);
     assert_eq!(size, 12);
+    let mut bytes = vec![0; size];
+    let written = bytes.pwrite_with(&b, 0, LE).unwrap();
+    assert_eq!(written, size);
     let mut read = 0;
-    let b: Data7B = BYTES.gread_with(&mut read, LE).unwrap();
-    assert_eq!(b.a.y, 1);
-    assert_eq!(b.a.x, 2);
+    let b2: Data7B = bytes.gread_with(&mut read, LE).unwrap();
     assert_eq!(read, size);
+    assert_eq!(b, b2);
 }


### PR DESCRIPTION
This fixes #15. I had this laying around but I had written the patch atop https://github.com/m4b/scroll_derive/pull/16 so I didn't want to submit a PR until that landed because GitHub is lousy at dealing with patches that have dependencies.

This might require explicitly bumping the required version of scroll used for the tests since it depends on https://github.com/m4b/scroll/pull/35 .